### PR TITLE
Force stable rustc.

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "stable"


### PR DESCRIPTION
The build fails, if this nightly is a default in rustup:

nightly-x86_64-apple-darwin (default)
rustc 1.57.0-nightly (8c2b6ea37 2021-09-11)

The build works on:
stable-x86_64-apple-darwin (default)
rustc 1.55.0 (c8dfcfe04 2021-09-06)