### PR TITLE
Split sentry PeerId usage into PeerId512 and PeerId256

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -357,9 +366,9 @@ version = "0.1.0"
 source = "git+https://github.com/tokio-rs/console#3d80c4b68b97db9c20cb496a2e3df0ccc1336b38"
 dependencies = [
  "prost 0.8.0",
- "prost-types",
- "tonic",
- "tonic-build",
+ "prost-types 0.8.0",
+ "tonic 0.5.2",
+ "tonic-build 0.5.2",
  "tracing-core",
 ]
 
@@ -377,7 +386,7 @@ dependencies = [
  "thread_local",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.5.2",
  "tracing",
  "tracing-core",
  "tracing-subscriber",
@@ -813,14 +822,14 @@ dependencies = [
 [[package]]
 name = "ethereum-interfaces"
 version = "0.1.0"
-source = "git+https://github.com/ledgerwatch/interfaces#b9b02cb6a62f8b7e2bb689b148492d0e4ad6d836"
+source = "git+https://github.com/ledgerwatch/interfaces#ed9b04802fe8891a2bc3fea274c498c758d3fcac"
 dependencies = [
  "arrayref",
  "ethereum-types",
- "prost 0.8.0",
- "prost-build",
- "tonic",
- "tonic-build",
+ "prost 0.9.0",
+ "prost-build 0.9.0",
+ "tonic 0.6.1",
+ "tonic-build 0.6.0",
 ]
 
 [[package]]
@@ -852,6 +861,7 @@ dependencies = [
  "hex-literal",
  "k256",
  "maplit",
+ "memchr",
  "num-traits",
  "parking_lot",
  "plain_hasher",
@@ -865,7 +875,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "toml",
- "tonic",
+ "tonic 0.6.1",
  "tonic-health",
  "tracing",
  "tracing-futures",
@@ -916,6 +926,12 @@ name = "fixedbitset"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "398ea4fabe40b9b0d885340a2a991a44c8a645624075ad966d21f88688e2b69e"
 
 [[package]]
 name = "flate2"
@@ -1254,9 +1270,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "399c583b2979440c60be0821a6199eca73bc3c8dcd9d070d75ac726e2c6186e5"
+checksum = "1ff4f84919677303da5f147645dbea6b1881f368d03ac84e1dc09031ebd7b2c6"
 dependencies = [
  "bytes",
  "http",
@@ -1283,9 +1299,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.13"
+version = "0.14.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15d1cfb9e4f68655fa04c01f59edb405b6074a0f7118ea881e5026e4a1cd8593"
+checksum = "436ec0091e4f20e655156a30a0df3770fe2900aa301e548e08446ec794b6953c"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1559,9 +1575,9 @@ checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "memchr"
-version = "2.3.4"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "miniz_oxide"
@@ -1603,9 +1619,9 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "nom"
-version = "6.2.1"
+version = "6.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c5c51b9083a3c620fa67a2a635d1ce7d95b897e957d6b28ff9a5da960a103a6"
+checksum = "e7413f999671bd4745a7b624bd370a569fb6bc574b23c83a3c5ed2e453f3d5e2"
 dependencies = [
  "bitvec 0.19.5",
  "funty",
@@ -1753,7 +1769,17 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
 dependencies = [
- "fixedbitset",
+ "fixedbitset 0.2.0",
+ "indexmap",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a13a2fa9d0b63e5f22328828741e523766fff0ee9e779316902290dff3f824f"
+dependencies = [
+ "fixedbitset 0.4.0",
  "indexmap",
 ]
 
@@ -1925,9 +1951,29 @@ dependencies = [
  "itertools",
  "log",
  "multimap",
- "petgraph",
+ "petgraph 0.5.1",
  "prost 0.8.0",
- "prost-types",
+ "prost-types 0.8.0",
+ "tempfile",
+ "which",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62941722fb675d463659e49c4f3fe1fe792ff24fe5bbaa9c08cd3b98a1c354f5"
+dependencies = [
+ "bytes",
+ "heck",
+ "itertools",
+ "lazy_static",
+ "log",
+ "multimap",
+ "petgraph 0.6.0",
+ "prost 0.9.0",
+ "prost-types 0.9.0",
+ "regex",
  "tempfile",
  "which",
 ]
@@ -1966,6 +2012,16 @@ checksum = "603bbd6394701d13f3f25aada59c7de9d35a6a5887cfc156181234a44002771b"
 dependencies = [
  "bytes",
  "prost 0.8.0",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
+dependencies = [
+ "bytes",
+ "prost 0.9.0",
 ]
 
 [[package]]
@@ -2206,6 +2262,8 @@ version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
 dependencies = [
+ "aho-corasick",
+ "memchr",
  "regex-syntax",
 ]
 
@@ -2778,6 +2836,37 @@ dependencies = [
  "prost 0.8.0",
  "prost-derive 0.8.0",
  "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "tonic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24203b79cf2d68909da91178db3026e77054effba0c5d93deb870d3ca7b35afa"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost 0.9.0",
+ "prost-derive 0.9.0",
+ "tokio",
  "tokio-rustls",
  "tokio-stream",
  "tokio-util",
@@ -2795,7 +2884,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12b52d07035516c2b74337d2ac7746075e7dcae7643816c1b12c5ff8a7484c08"
 dependencies = [
  "proc-macro2",
- "prost-build",
+ "prost-build 0.8.0",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88358bb1dcfeb62dcce85c63006cafb964b7be481d522b7e09589d4d1e718d2a"
+dependencies = [
+ "proc-macro2",
+ "prost-build 0.9.0",
  "quote",
  "syn",
 ]
@@ -2811,8 +2912,8 @@ dependencies = [
  "prost 0.8.0",
  "tokio",
  "tokio-stream",
- "tonic",
- "tonic-build",
+ "tonic 0.5.2",
+ "tonic-build 0.5.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2903,17 +2903,17 @@ dependencies = [
 
 [[package]]
 name = "tonic-health"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "493fcae35818dffa28437b210a615119d791116c1cac80716f571f35dd55b1b9"
+checksum = "7ae388bee1d4e52c9dc334f0d5918757b07b3ffafafd7953d254c7a0e8605e02"
 dependencies = [
  "async-stream",
  "bytes",
- "prost 0.8.0",
+ "prost 0.9.0",
  "tokio",
  "tokio-stream",
- "tonic 0.5.2",
- "tonic-build 0.5.2",
+ "tonic 0.6.1",
+ "tonic-build 0.6.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ hex = "0.4"
 hex-literal = "0.3"
 k256 = { version = "0.8", features = ["ecdsa"] }
 maplit = "1"
+memchr = "2.4.1"
 num-traits = "0.2"
 parking_lot = "0.11"
 plain_hasher = "0.2"
@@ -49,7 +50,7 @@ task-group = { git = "https://github.com/vorot93/task-group" }
 tokio = { version = "1", features = ["full", "tracing"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 toml = "0.5"
-tonic = { version = "0.5", features = ["tls"] }
+tonic = { version = "0.6", features = ["tls"] }
 tonic-health = "0.4"
 tracing = "0.1"
 tracing-futures = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ tokio = { version = "1", features = ["full", "tracing"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 toml = "0.5"
 tonic = { version = "0.6", features = ["tls"] }
-tonic-health = "0.4"
+tonic-health = "0.5.0"
 tracing = "0.1"
 tracing-futures = "0.2"
 tracing-subscriber = "0.2"

--- a/devp2p/examples/handshake.rs
+++ b/devp2p/examples/handshake.rs
@@ -1,10 +1,10 @@
-use devp2p::{ecies::ECIESStream, PeerId512};
+use devp2p::{ecies::ECIESStream, PeerIdPubKey};
 use hex_literal::hex;
 use secp256k1::SecretKey;
 use tokio::net::TcpStream;
 use tracing_subscriber::EnvFilter;
 
-const REMOTE_ID: PeerId512 = PeerId512(hex!("d860a01f9722d78051619d1e2351aba3f43f943f6f00718d1b9baa4101932a1f5011f16bb2b1bb35db20d6fe28fa0bf09636d26a87d31de9ec6203eeedb1f666"));
+const REMOTE_ID: PeerIdPubKey = PeerIdPubKey(hex!("d860a01f9722d78051619d1e2351aba3f43f943f6f00718d1b9baa4101932a1f5011f16bb2b1bb35db20d6fe28fa0bf09636d26a87d31de9ec6203eeedb1f666"));
 
 #[tokio::main]
 async fn main() {

--- a/devp2p/examples/handshake.rs
+++ b/devp2p/examples/handshake.rs
@@ -1,10 +1,10 @@
-use devp2p::{ecies::ECIESStream, PeerId};
+use devp2p::{ecies::ECIESStream, PeerId512};
 use hex_literal::hex;
 use secp256k1::SecretKey;
 use tokio::net::TcpStream;
 use tracing_subscriber::EnvFilter;
 
-const REMOTE_ID: PeerId = PeerId(hex!("d860a01f9722d78051619d1e2351aba3f43f943f6f00718d1b9baa4101932a1f5011f16bb2b1bb35db20d6fe28fa0bf09636d26a87d31de9ec6203eeedb1f666"));
+const REMOTE_ID: PeerId512 = PeerId512(hex!("d860a01f9722d78051619d1e2351aba3f43f943f6f00718d1b9baa4101932a1f5011f16bb2b1bb35db20d6fe28fa0bf09636d26a87d31de9ec6203eeedb1f666"));
 
 #[tokio::main]
 async fn main() {

--- a/devp2p/examples/local_connect.rs
+++ b/devp2p/examples/local_connect.rs
@@ -15,17 +15,17 @@ struct DummyServer;
 #[async_trait]
 impl CapabilityServer for DummyServer {
     #[instrument(skip(self, peer), fields(peer=&*peer.to_string()))]
-    fn on_peer_connect(&self, peer: PeerId256, _: HashMap<CapabilityName, CapabilityVersion>) {
+    fn on_peer_connect(&self, peer: PeerIdHash, _: HashMap<CapabilityName, CapabilityVersion>) {
         info!("Peer connected")
     }
 
     #[instrument(skip(self, _peer, _event), fields(peer=&*_peer.to_string(), event=&*_event.to_string()))]
-    async fn on_peer_event(&self, _peer: PeerId256, _event: InboundEvent) {
+    async fn on_peer_event(&self, _peer: PeerIdHash, _event: InboundEvent) {
         info!("Received event");
     }
 
     #[instrument(skip(self, _peer), fields(peer=&*_peer.to_string()))]
-    async fn next(&self, _peer: PeerId256) -> OutboundEvent {
+    async fn next(&self, _peer: PeerIdHash) -> OutboundEvent {
         futures::future::pending().await
     }
 }

--- a/devp2p/examples/local_connect.rs
+++ b/devp2p/examples/local_connect.rs
@@ -15,17 +15,17 @@ struct DummyServer;
 #[async_trait]
 impl CapabilityServer for DummyServer {
     #[instrument(skip(self, peer), fields(peer=&*peer.to_string()))]
-    fn on_peer_connect(&self, peer: PeerId, _: HashMap<CapabilityName, CapabilityVersion>) {
+    fn on_peer_connect(&self, peer: PeerId512, _: HashMap<CapabilityName, CapabilityVersion>) {
         info!("Peer connected")
     }
 
     #[instrument(skip(self, _peer, _event), fields(peer=&*_peer.to_string(), event=&*_event.to_string()))]
-    async fn on_peer_event(&self, _peer: PeerId, _event: InboundEvent) {
+    async fn on_peer_event(&self, _peer: PeerId512, _event: InboundEvent) {
         info!("Received event");
     }
 
     #[instrument(skip(self, _peer), fields(peer=&*_peer.to_string()))]
-    async fn next(&self, _peer: PeerId) -> OutboundEvent {
+    async fn next(&self, _peer: PeerId512) -> OutboundEvent {
         futures::future::pending().await
     }
 }

--- a/devp2p/examples/local_connect.rs
+++ b/devp2p/examples/local_connect.rs
@@ -15,17 +15,17 @@ struct DummyServer;
 #[async_trait]
 impl CapabilityServer for DummyServer {
     #[instrument(skip(self, peer), fields(peer=&*peer.to_string()))]
-    fn on_peer_connect(&self, peer: PeerId512, _: HashMap<CapabilityName, CapabilityVersion>) {
+    fn on_peer_connect(&self, peer: PeerId256, _: HashMap<CapabilityName, CapabilityVersion>) {
         info!("Peer connected")
     }
 
     #[instrument(skip(self, _peer, _event), fields(peer=&*_peer.to_string(), event=&*_event.to_string()))]
-    async fn on_peer_event(&self, _peer: PeerId512, _event: InboundEvent) {
+    async fn on_peer_event(&self, _peer: PeerId256, _event: InboundEvent) {
         info!("Received event");
     }
 
     #[instrument(skip(self, _peer), fields(peer=&*_peer.to_string()))]
-    async fn next(&self, _peer: PeerId512) -> OutboundEvent {
+    async fn next(&self, _peer: PeerId256) -> OutboundEvent {
         futures::future::pending().await
     }
 }

--- a/devp2p/examples/sentry.rs
+++ b/devp2p/examples/sentry.rs
@@ -83,17 +83,17 @@ struct Pipes {
 
 #[derive(Default)]
 struct CapabilityServerImpl {
-    peer_pipes: Arc<RwLock<HashMap<PeerId512, Pipes>>>,
+    peer_pipes: Arc<RwLock<HashMap<PeerId256, Pipes>>>,
 }
 
 impl CapabilityServerImpl {
-    fn setup_pipes(&self, peer: PeerId512, pipes: Pipes) {
+    fn setup_pipes(&self, peer: PeerId256, pipes: Pipes) {
         assert!(self.peer_pipes.write().insert(peer, pipes).is_none());
     }
-    fn get_pipes(&self, peer: PeerId512) -> Pipes {
+    fn get_pipes(&self, peer: PeerId256) -> Pipes {
         self.peer_pipes.read().get(&peer).unwrap().clone()
     }
-    fn teardown(&self, peer: PeerId512) {
+    fn teardown(&self, peer: PeerId256) {
         self.peer_pipes.write().remove(&peer);
     }
     fn connected_peers(&self) -> usize {
@@ -104,7 +104,7 @@ impl CapabilityServerImpl {
 #[async_trait]
 impl CapabilityServer for CapabilityServerImpl {
     #[instrument(skip(self, peer), fields(peer=&*peer.to_string()))]
-    fn on_peer_connect(&self, peer: PeerId512, caps: HashMap<CapabilityName, CapabilityVersion>) {
+    fn on_peer_connect(&self, peer: PeerId256, caps: HashMap<CapabilityName, CapabilityVersion>) {
         info!("Setting up peer state");
         let status_message = StatusMessage {
             protocol_version: *caps.get(&eth()).unwrap(),
@@ -143,7 +143,7 @@ impl CapabilityServer for CapabilityServerImpl {
         );
     }
     #[instrument(skip(self, peer, event), fields(peer=&*peer.to_string(), event=&*event.to_string()))]
-    async fn on_peer_event(&self, peer: PeerId512, event: InboundEvent) {
+    async fn on_peer_event(&self, peer: PeerId256, event: InboundEvent) {
         match event {
             InboundEvent::Disconnect { .. } => {
                 self.teardown(peer);
@@ -198,7 +198,7 @@ impl CapabilityServer for CapabilityServerImpl {
         }
     }
     #[instrument(skip(self, peer), fields(peer=&*peer.to_string()))]
-    async fn next(&self, peer: PeerId512) -> OutboundEvent {
+    async fn next(&self, peer: PeerId256) -> OutboundEvent {
         let outbound = self
             .get_pipes(peer)
             .receiver

--- a/devp2p/examples/sentry.rs
+++ b/devp2p/examples/sentry.rs
@@ -83,17 +83,17 @@ struct Pipes {
 
 #[derive(Default)]
 struct CapabilityServerImpl {
-    peer_pipes: Arc<RwLock<HashMap<PeerId, Pipes>>>,
+    peer_pipes: Arc<RwLock<HashMap<PeerId512, Pipes>>>,
 }
 
 impl CapabilityServerImpl {
-    fn setup_pipes(&self, peer: PeerId, pipes: Pipes) {
+    fn setup_pipes(&self, peer: PeerId512, pipes: Pipes) {
         assert!(self.peer_pipes.write().insert(peer, pipes).is_none());
     }
-    fn get_pipes(&self, peer: PeerId) -> Pipes {
+    fn get_pipes(&self, peer: PeerId512) -> Pipes {
         self.peer_pipes.read().get(&peer).unwrap().clone()
     }
-    fn teardown(&self, peer: PeerId) {
+    fn teardown(&self, peer: PeerId512) {
         self.peer_pipes.write().remove(&peer);
     }
     fn connected_peers(&self) -> usize {
@@ -104,7 +104,7 @@ impl CapabilityServerImpl {
 #[async_trait]
 impl CapabilityServer for CapabilityServerImpl {
     #[instrument(skip(self, peer), fields(peer=&*peer.to_string()))]
-    fn on_peer_connect(&self, peer: PeerId, caps: HashMap<CapabilityName, CapabilityVersion>) {
+    fn on_peer_connect(&self, peer: PeerId512, caps: HashMap<CapabilityName, CapabilityVersion>) {
         info!("Setting up peer state");
         let status_message = StatusMessage {
             protocol_version: *caps.get(&eth()).unwrap(),
@@ -143,7 +143,7 @@ impl CapabilityServer for CapabilityServerImpl {
         );
     }
     #[instrument(skip(self, peer, event), fields(peer=&*peer.to_string(), event=&*event.to_string()))]
-    async fn on_peer_event(&self, peer: PeerId, event: InboundEvent) {
+    async fn on_peer_event(&self, peer: PeerId512, event: InboundEvent) {
         match event {
             InboundEvent::Disconnect { .. } => {
                 self.teardown(peer);
@@ -198,7 +198,7 @@ impl CapabilityServer for CapabilityServerImpl {
         }
     }
     #[instrument(skip(self, peer), fields(peer=&*peer.to_string()))]
-    async fn next(&self, peer: PeerId) -> OutboundEvent {
+    async fn next(&self, peer: PeerId512) -> OutboundEvent {
         let outbound = self
             .get_pipes(peer)
             .receiver

--- a/devp2p/examples/sentry.rs
+++ b/devp2p/examples/sentry.rs
@@ -83,17 +83,17 @@ struct Pipes {
 
 #[derive(Default)]
 struct CapabilityServerImpl {
-    peer_pipes: Arc<RwLock<HashMap<PeerId256, Pipes>>>,
+    peer_pipes: Arc<RwLock<HashMap<PeerIdHash, Pipes>>>,
 }
 
 impl CapabilityServerImpl {
-    fn setup_pipes(&self, peer: PeerId256, pipes: Pipes) {
+    fn setup_pipes(&self, peer: PeerIdHash, pipes: Pipes) {
         assert!(self.peer_pipes.write().insert(peer, pipes).is_none());
     }
-    fn get_pipes(&self, peer: PeerId256) -> Pipes {
+    fn get_pipes(&self, peer: PeerIdHash) -> Pipes {
         self.peer_pipes.read().get(&peer).unwrap().clone()
     }
-    fn teardown(&self, peer: PeerId256) {
+    fn teardown(&self, peer: PeerIdHash) {
         self.peer_pipes.write().remove(&peer);
     }
     fn connected_peers(&self) -> usize {
@@ -104,7 +104,7 @@ impl CapabilityServerImpl {
 #[async_trait]
 impl CapabilityServer for CapabilityServerImpl {
     #[instrument(skip(self, peer), fields(peer=&*peer.to_string()))]
-    fn on_peer_connect(&self, peer: PeerId256, caps: HashMap<CapabilityName, CapabilityVersion>) {
+    fn on_peer_connect(&self, peer: PeerIdHash, caps: HashMap<CapabilityName, CapabilityVersion>) {
         info!("Setting up peer state");
         let status_message = StatusMessage {
             protocol_version: *caps.get(&eth()).unwrap(),
@@ -143,7 +143,7 @@ impl CapabilityServer for CapabilityServerImpl {
         );
     }
     #[instrument(skip(self, peer, event), fields(peer=&*peer.to_string(), event=&*event.to_string()))]
-    async fn on_peer_event(&self, peer: PeerId256, event: InboundEvent) {
+    async fn on_peer_event(&self, peer: PeerIdHash, event: InboundEvent) {
         match event {
             InboundEvent::Disconnect { .. } => {
                 self.teardown(peer);
@@ -198,7 +198,7 @@ impl CapabilityServer for CapabilityServerImpl {
         }
     }
     #[instrument(skip(self, peer), fields(peer=&*peer.to_string()))]
-    async fn next(&self, peer: PeerId256) -> OutboundEvent {
+    async fn next(&self, peer: PeerIdHash) -> OutboundEvent {
         let outbound = self
             .get_pipes(peer)
             .receiver

--- a/devp2p/src/disc.rs
+++ b/devp2p/src/disc.rs
@@ -34,7 +34,7 @@ pub type Discovery = BoxStream<'static, anyhow::Result<NodeRecord>>;
 pub struct StaticNodes(Pin<Box<dyn Stream<Item = anyhow::Result<NodeRecord>> + Send + 'static>>);
 
 impl StaticNodes {
-    pub fn new(nodes: HashMap<SocketAddr, PeerId>, delay: Duration) -> Self {
+    pub fn new(nodes: HashMap<SocketAddr, PeerId512>, delay: Duration) -> Self {
         Self(Box::pin(stream! {
             loop {
                 for (&addr, &id) in &nodes {

--- a/devp2p/src/disc.rs
+++ b/devp2p/src/disc.rs
@@ -34,7 +34,7 @@ pub type Discovery = BoxStream<'static, anyhow::Result<NodeRecord>>;
 pub struct StaticNodes(Pin<Box<dyn Stream<Item = anyhow::Result<NodeRecord>> + Send + 'static>>);
 
 impl StaticNodes {
-    pub fn new(nodes: HashMap<SocketAddr, PeerId512>, delay: Duration) -> Self {
+    pub fn new(nodes: HashMap<SocketAddr, PeerIdPubKey>, delay: Duration) -> Self {
         Self(Box::pin(stream! {
             loop {
                 for (&addr, &id) in &nodes {

--- a/devp2p/src/disc/dns.rs
+++ b/devp2p/src/disc/dns.rs
@@ -50,7 +50,7 @@ impl DnsDiscovery {
                                 if tx
                                     .send(Ok(NodeRecord {
                                         addr,
-                                        id: pk_to_id512(&v.public_key()),
+                                        id: pk_to_id_pub_key(&v.public_key()),
                                     }))
                                     .await
                                     .is_err()

--- a/devp2p/src/disc/dns.rs
+++ b/devp2p/src/disc/dns.rs
@@ -50,7 +50,7 @@ impl DnsDiscovery {
                                 if tx
                                     .send(Ok(NodeRecord {
                                         addr,
-                                        id: pk2id(&v.public_key()),
+                                        id: pk_to_id512(&v.public_key()),
                                     }))
                                     .await
                                     .is_err()

--- a/devp2p/src/disc/v5.rs
+++ b/devp2p/src/disc/v5.rs
@@ -48,7 +48,7 @@ impl Discv5 {
                                                 if tx
                                                     .send(NodeRecord {
                                                         addr: (ip, port).into(),
-                                                        id: pk2id(
+                                                        id: pk_to_id512(
                                                             &PublicKey::from_slice(&pk.to_bytes())
                                                                 .unwrap(),
                                                         ),

--- a/devp2p/src/disc/v5.rs
+++ b/devp2p/src/disc/v5.rs
@@ -48,7 +48,7 @@ impl Discv5 {
                                                 if tx
                                                     .send(NodeRecord {
                                                         addr: (ip, port).into(),
-                                                        id: pk_to_id512(
+                                                        id: pk_to_id_pub_key(
                                                             &PublicKey::from_slice(&pk.to_bytes())
                                                                 .unwrap(),
                                                         ),

--- a/devp2p/src/ecies/algorithm.rs
+++ b/devp2p/src/ecies/algorithm.rs
@@ -2,7 +2,7 @@ use crate::{
     errors::ECIESError,
     mac::*,
     types::*,
-    util::{hmac_sha256, id2pk, pk2id, sha256},
+    util::{hmac_sha256, id2pk, pk_to_id512, sha256},
 };
 use aes::{
     cipher::{NewCipher, StreamCipher},
@@ -249,7 +249,7 @@ impl ECIES {
         sig_bytes[64] = rec_id.to_i32() as u8;
         let mut out = RlpStream::new_list(4);
         out.append(&(&sig_bytes as &[u8]));
-        out.append(&pk2id(&self.public_key));
+        out.append(&pk_to_id512(&self.public_key));
         out.append(&self.nonce);
         out.append(&PROTOCOL_VERSION);
 
@@ -332,7 +332,7 @@ impl ECIES {
 
     fn create_ack_unencrypted(&self) -> BytesMut {
         let mut out = RlpStream::new_list(3);
-        out.append(&pk2id(&self.ephemeral_public_key));
+        out.append(&pk_to_id512(&self.ephemeral_public_key));
         out.append(&self.nonce);
         out.append(&PROTOCOL_VERSION);
         out.out()
@@ -587,7 +587,7 @@ mod tests {
 
         let mut server_ecies = ECIES::new_server(server_secret_key).unwrap();
         let mut client_ecies =
-            ECIES::new_client(client_secret_key, pk2id(&server_public_key)).unwrap();
+            ECIES::new_client(client_secret_key, pk_to_id512(&server_public_key)).unwrap();
 
         // Handshake
         let mut auth = client_ecies.create_auth();
@@ -670,7 +670,7 @@ mod tests {
             "7e968bba13b6c50e2c4cd7f241cc0d64d1ac25c7f5952df231ac6a2bda8ee5d6"
         ));
 
-        let server_id = pk2id(&PublicKey::from_secret_key(
+        let server_id = pk_to_id512(&PublicKey::from_secret_key(
             SECP256K1,
             &eip8_test_server_key(),
         ));

--- a/devp2p/src/ecies/algorithm.rs
+++ b/devp2p/src/ecies/algorithm.rs
@@ -65,7 +65,7 @@ pub struct ECIES {
     public_key: PublicKey,
     remote_public_key: Option<PublicKey>,
 
-    pub(crate) remote_id: Option<PeerId>,
+    pub(crate) remote_id: Option<PeerId512>,
 
     #[educe(Debug(ignore))]
     ephemeral_secret_key: SecretKey,
@@ -90,7 +90,7 @@ pub struct ECIES {
 impl ECIES {
     fn new_static_client(
         secret_key: SecretKey,
-        remote_id: PeerId,
+        remote_id: PeerId512,
         nonce: H256,
         ephemeral_secret_key: SecretKey,
     ) -> Result<Self, ECIESError> {
@@ -122,7 +122,7 @@ impl ECIES {
         })
     }
 
-    pub fn new_client(secret_key: SecretKey, remote_id: PeerId) -> Result<Self, ECIESError> {
+    pub fn new_client(secret_key: SecretKey, remote_id: PeerId512) -> Result<Self, ECIESError> {
         let nonce = H256::random();
         let ephemeral_secret_key = SecretKey::new(&mut secp256k1::rand::thread_rng());
 
@@ -168,7 +168,7 @@ impl ECIES {
         Self::new_static_server(secret_key, nonce, ephemeral_secret_key)
     }
 
-    pub fn remote_id(&self) -> PeerId {
+    pub fn remote_id(&self) -> PeerId512 {
         self.remote_id.unwrap()
     }
 

--- a/devp2p/src/ecies/proto.rs
+++ b/devp2p/src/ecies/proto.rs
@@ -1,5 +1,5 @@
 use super::algorithm::ECIES;
-use crate::{errors::ECIESError, transport::Transport, types::PeerId};
+use crate::{errors::ECIESError, transport::Transport, types::PeerId512};
 use anyhow::{bail, Context as _};
 use bytes::{Bytes, BytesMut};
 use futures::{ready, Sink, SinkExt};
@@ -34,7 +34,7 @@ pub enum EgressECIESValue {
 #[derive(Clone, Debug, PartialEq, Eq)]
 /// Raw ingress values for an ECIES protocol
 pub enum IngressECIESValue {
-    AuthReceive(PeerId),
+    AuthReceive(PeerId512),
     Ack,
     Message(Bytes),
 }
@@ -56,7 +56,7 @@ impl ECIESCodec {
     }
 
     /// Create a new client codec using the given secret key and the server's public id
-    pub fn new_client(secret_key: SecretKey, remote_id: PeerId) -> Result<Self, ECIESError> {
+    pub fn new_client(secret_key: SecretKey, remote_id: PeerId512) -> Result<Self, ECIESError> {
         Ok(Self {
             ecies: ECIES::new_client(secret_key, remote_id)?,
             state: ECIESState::Auth,
@@ -165,7 +165,7 @@ impl Encoder<EgressECIESValue> for ECIESCodec {
 #[derive(Debug)]
 pub struct ECIESStream<Io> {
     stream: Framed<Io, ECIESCodec>,
-    remote_id: PeerId,
+    remote_id: PeerId512,
 }
 
 impl<Io> ECIESStream<Io>
@@ -177,7 +177,7 @@ where
     pub async fn connect(
         transport: Io,
         secret_key: SecretKey,
-        remote_id: PeerId,
+        remote_id: PeerId512,
     ) -> anyhow::Result<Self> {
         let ecies = ECIESCodec::new_client(secret_key, remote_id)
             .map_err(|_| io::Error::new(io::ErrorKind::Other, "invalid handshake"))?;
@@ -232,7 +232,7 @@ where
     }
 
     /// Get the remote id
-    pub fn remote_id(&self) -> PeerId {
+    pub fn remote_id(&self) -> PeerId512 {
         self.remote_id
     }
 }

--- a/devp2p/src/lib.rs
+++ b/devp2p/src/lib.rs
@@ -24,5 +24,5 @@ pub use peer::{DisconnectReason, PeerStream};
 pub use rlpx::{ListenOptions, Swarm, SwarmBuilder};
 pub use types::{
     CapabilityId, CapabilityInfo, CapabilityName, CapabilityServer, CapabilityVersion,
-    InboundEvent, Message, NodeRecord, OutboundEvent, PeerId256, PeerId512,
+    InboundEvent, Message, NodeRecord, OutboundEvent, PeerIdHash, PeerIdPubKey,
 };

--- a/devp2p/src/lib.rs
+++ b/devp2p/src/lib.rs
@@ -24,5 +24,5 @@ pub use peer::{DisconnectReason, PeerStream};
 pub use rlpx::{ListenOptions, Swarm, SwarmBuilder};
 pub use types::{
     CapabilityId, CapabilityInfo, CapabilityName, CapabilityServer, CapabilityVersion,
-    InboundEvent, Message, NodeRecord, OutboundEvent, PeerId,
+    InboundEvent, Message, NodeRecord, OutboundEvent, PeerId512,
 };

--- a/devp2p/src/lib.rs
+++ b/devp2p/src/lib.rs
@@ -24,5 +24,5 @@ pub use peer::{DisconnectReason, PeerStream};
 pub use rlpx::{ListenOptions, Swarm, SwarmBuilder};
 pub use types::{
     CapabilityId, CapabilityInfo, CapabilityName, CapabilityServer, CapabilityVersion,
-    InboundEvent, Message, NodeRecord, OutboundEvent, PeerId512,
+    InboundEvent, Message, NodeRecord, OutboundEvent, PeerId256, PeerId512,
 };

--- a/devp2p/src/node_filter.rs
+++ b/devp2p/src/node_filter.rs
@@ -1,4 +1,4 @@
-use crate::types::PeerId512;
+use crate::types::PeerIdPubKey;
 use std::{
     collections::HashSet,
     fmt::Debug,
@@ -10,17 +10,17 @@ use std::{
 
 pub trait NodeFilter: Debug + Send + 'static {
     fn max_peers(&self) -> usize;
-    fn is_banned(&self, id: PeerId512) -> bool;
-    fn is_allowed(&self, pool_size: usize, id: PeerId512) -> bool {
+    fn is_banned(&self, id: PeerIdPubKey) -> bool;
+    fn is_allowed(&self, pool_size: usize, id: PeerIdPubKey) -> bool {
         pool_size < self.max_peers() && !self.is_banned(id)
     }
-    fn ban(&mut self, id: PeerId512);
+    fn ban(&mut self, id: PeerIdPubKey);
 }
 
 #[derive(Debug)]
 pub struct MemoryNodeFilter {
     peer_limiter: Arc<AtomicUsize>,
-    ban_list: HashSet<PeerId512>,
+    ban_list: HashSet<PeerIdPubKey>,
 }
 
 impl MemoryNodeFilter {
@@ -37,11 +37,11 @@ impl NodeFilter for MemoryNodeFilter {
         self.peer_limiter.load(Ordering::Relaxed)
     }
 
-    fn is_banned(&self, id: PeerId512) -> bool {
+    fn is_banned(&self, id: PeerIdPubKey) -> bool {
         self.ban_list.contains(&id)
     }
 
-    fn ban(&mut self, id: PeerId512) {
+    fn ban(&mut self, id: PeerIdPubKey) {
         self.ban_list.insert(id);
     }
 }

--- a/devp2p/src/node_filter.rs
+++ b/devp2p/src/node_filter.rs
@@ -1,4 +1,4 @@
-use crate::types::PeerId;
+use crate::types::PeerId512;
 use std::{
     collections::HashSet,
     fmt::Debug,
@@ -10,17 +10,17 @@ use std::{
 
 pub trait NodeFilter: Debug + Send + 'static {
     fn max_peers(&self) -> usize;
-    fn is_banned(&self, id: PeerId) -> bool;
-    fn is_allowed(&self, pool_size: usize, id: PeerId) -> bool {
+    fn is_banned(&self, id: PeerId512) -> bool;
+    fn is_allowed(&self, pool_size: usize, id: PeerId512) -> bool {
         pool_size < self.max_peers() && !self.is_banned(id)
     }
-    fn ban(&mut self, id: PeerId);
+    fn ban(&mut self, id: PeerId512);
 }
 
 #[derive(Debug)]
 pub struct MemoryNodeFilter {
     peer_limiter: Arc<AtomicUsize>,
-    ban_list: HashSet<PeerId>,
+    ban_list: HashSet<PeerId512>,
 }
 
 impl MemoryNodeFilter {
@@ -37,11 +37,11 @@ impl NodeFilter for MemoryNodeFilter {
         self.peer_limiter.load(Ordering::Relaxed)
     }
 
-    fn is_banned(&self, id: PeerId) -> bool {
+    fn is_banned(&self, id: PeerId512) -> bool {
         self.ban_list.contains(&id)
     }
 
-    fn ban(&mut self, id: PeerId) {
+    fn ban(&mut self, id: PeerId512) {
         self.ban_list.insert(id);
     }
 }

--- a/devp2p/src/peer.rs
+++ b/devp2p/src/peer.rs
@@ -1,4 +1,4 @@
-use crate::{ecies::ECIESStream, transport::Transport, types::*, util::pk_to_id512};
+use crate::{ecies::ECIESStream, transport::Transport, types::*, util::pk_to_id_pub_key};
 use anyhow::{anyhow, bail, Context as _};
 use bytes::{Bytes, BytesMut};
 use derive_more::Display;
@@ -84,7 +84,7 @@ pub struct HelloMessage {
     pub client_version: String,
     pub capabilities: Vec<CapabilityMessage>,
     pub port: u16,
-    pub id: PeerId512,
+    pub id: PeerIdPubKey,
 }
 
 impl Encodable for HelloMessage {
@@ -133,8 +133,8 @@ pub struct PeerStream<Io> {
     client_version: String,
     shared_capabilities: Vec<CapabilityInfo>,
     port: u16,
-    id: PeerId512,
-    remote_id: PeerId512,
+    id: PeerIdPubKey,
+    remote_id: PeerIdPubKey,
 
     snappy: Snappy,
 
@@ -146,7 +146,7 @@ where
     Io: Transport,
 {
     /// Remote public id of this peer
-    pub fn remote_id(&self) -> PeerId512 {
+    pub fn remote_id(&self) -> PeerIdPubKey {
         self.remote_id
     }
 
@@ -163,7 +163,7 @@ where
     pub async fn connect(
         transport: Io,
         secret_key: SecretKey,
-        remote_id: PeerId512,
+        remote_id: PeerIdPubKey,
         client_version: String,
         capabilities: Vec<CapabilityInfo>,
         port: u16,
@@ -210,7 +210,7 @@ where
         port: u16,
     ) -> anyhow::Result<Self> {
         let public_key = PublicKey::from_secret_key(SECP256K1, &secret_key);
-        let id = pk_to_id512(&public_key);
+        let id = pk_to_id_pub_key(&public_key);
         let nonhello_capabilities = capabilities.clone();
         let nonhello_client_version = client_version.clone();
 

--- a/devp2p/src/peer.rs
+++ b/devp2p/src/peer.rs
@@ -1,4 +1,4 @@
-use crate::{ecies::ECIESStream, transport::Transport, types::*, util::pk2id};
+use crate::{ecies::ECIESStream, transport::Transport, types::*, util::pk_to_id512};
 use anyhow::{anyhow, bail, Context as _};
 use bytes::{Bytes, BytesMut};
 use derive_more::Display;
@@ -210,7 +210,7 @@ where
         port: u16,
     ) -> anyhow::Result<Self> {
         let public_key = PublicKey::from_secret_key(SECP256K1, &secret_key);
-        let id = pk2id(&public_key);
+        let id = pk_to_id512(&public_key);
         let nonhello_capabilities = capabilities.clone();
         let nonhello_client_version = client_version.clone();
 

--- a/devp2p/src/peer.rs
+++ b/devp2p/src/peer.rs
@@ -84,7 +84,7 @@ pub struct HelloMessage {
     pub client_version: String,
     pub capabilities: Vec<CapabilityMessage>,
     pub port: u16,
-    pub id: PeerId,
+    pub id: PeerId512,
 }
 
 impl Encodable for HelloMessage {
@@ -133,8 +133,8 @@ pub struct PeerStream<Io> {
     client_version: String,
     shared_capabilities: Vec<CapabilityInfo>,
     port: u16,
-    id: PeerId,
-    remote_id: PeerId,
+    id: PeerId512,
+    remote_id: PeerId512,
 
     snappy: Snappy,
 
@@ -146,7 +146,7 @@ where
     Io: Transport,
 {
     /// Remote public id of this peer
-    pub fn remote_id(&self) -> PeerId {
+    pub fn remote_id(&self) -> PeerId512 {
         self.remote_id
     }
 
@@ -163,7 +163,7 @@ where
     pub async fn connect(
         transport: Io,
         secret_key: SecretKey,
-        remote_id: PeerId,
+        remote_id: PeerId512,
         client_version: String,
         capabilities: Vec<CapabilityInfo>,
         port: u16,

--- a/devp2p/src/rlpx.rs
+++ b/devp2p/src/rlpx.rs
@@ -5,7 +5,8 @@ use crate::{
     node_filter::{MemoryNodeFilter, NodeFilter},
     peer::*,
     transport::{TcpServer, TokioCidrListener, Transport},
-    types::*, util::id512_to_id256,
+    types::*,
+    util::id512_to_id256,
 };
 use anyhow::{anyhow, bail, Context};
 use cidr::IpCidr;
@@ -221,7 +222,12 @@ where
 
             let _ = peer_disconnect_tx.send(disconnect_signal);
         }
-        .instrument(span!(Level::DEBUG, "IN", "peer={}", remote_id512.to_string(),))
+        .instrument(span!(
+            Level::DEBUG,
+            "IN",
+            "peer={}",
+            remote_id512.to_string(),
+        ))
     });
 
     // This will send our packets to peer.

--- a/devp2p/src/rlpx.rs
+++ b/devp2p/src/rlpx.rs
@@ -77,11 +77,11 @@ impl PeerState {
 #[derive(Debug, Default)]
 struct PeerStreams {
     /// Mapping of remote IDs to streams in `StreamMap`
-    mapping: HashMap<PeerId, PeerState>,
+    mapping: HashMap<PeerId512, PeerState>,
 }
 
 impl PeerStreams {
-    fn disconnect_peer(&mut self, remote_id: PeerId) -> bool {
+    fn disconnect_peer(&mut self, remote_id: PeerId512) -> bool {
         debug!("disconnecting peer {}", remote_id);
 
         self.mapping.remove(&remote_id).is_some()
@@ -139,7 +139,7 @@ async fn handle_incoming<TS, C>(
 fn setup_peer_state<C, Io>(
     streams: Weak<Mutex<PeerStreams>>,
     capability_server: Arc<C>,
-    remote_id: PeerId,
+    remote_id: PeerId512,
     peer: PeerStream<Io>,
 ) -> ConnectedPeerState
 where
@@ -678,7 +678,7 @@ impl<C: CapabilityServer> Swarm<C> {
     fn add_peer_inner(
         &self,
         addr: SocketAddr,
-        remote_id: PeerId,
+        remote_id: PeerId512,
         untrusted_peer: bool,
     ) -> impl Future<Output = anyhow::Result<bool>> + Send + 'static {
         let tasks = self.tasks.clone();

--- a/devp2p/src/types.rs
+++ b/devp2p/src/types.rs
@@ -5,7 +5,7 @@ use auto_impl::auto_impl;
 use bytes::Bytes;
 use derive_more::Display;
 use educe::Educe;
-pub use ethereum_types::{H256 as PeerId256, H512 as PeerId512};
+pub use ethereum_types::{H256 as PeerIdHash, H512 as PeerIdPubKey};
 use rlp::{DecoderError, Rlp, RlpStream};
 use std::{collections::HashMap, fmt::Debug, net::SocketAddr, str::FromStr};
 
@@ -13,7 +13,7 @@ use std::{collections::HashMap, fmt::Debug, net::SocketAddr, str::FromStr};
 #[derive(Clone, Copy, Debug)]
 pub struct NodeRecord {
     /// Node ID.
-    pub id: PeerId512,
+    pub id: PeerIdPubKey,
     /// Address of RLPx TCP server.
     pub addr: SocketAddr,
 }
@@ -121,20 +121,20 @@ pub enum OutboundEvent {
 #[auto_impl(&, Box, Arc)]
 pub trait CapabilityServer: Send + Sync + 'static {
     /// Should be used to set up relevant state for the peer.
-    fn on_peer_connect(&self, peer: PeerId256, caps: HashMap<CapabilityName, CapabilityVersion>);
+    fn on_peer_connect(&self, peer: PeerIdHash, caps: HashMap<CapabilityName, CapabilityVersion>);
     /// Called on the next event for peer.
-    async fn on_peer_event(&self, peer: PeerId256, event: InboundEvent);
+    async fn on_peer_event(&self, peer: PeerIdHash, event: InboundEvent);
     /// Get the next event for peer.
-    async fn next(&self, peer: PeerId256) -> OutboundEvent;
+    async fn next(&self, peer: PeerIdHash) -> OutboundEvent;
 }
 
 #[async_trait]
 impl CapabilityServer for () {
-    fn on_peer_connect(&self, _: PeerId256, _: HashMap<CapabilityName, CapabilityVersion>) {}
+    fn on_peer_connect(&self, _: PeerIdHash, _: HashMap<CapabilityName, CapabilityVersion>) {}
 
-    async fn on_peer_event(&self, _: PeerId256, _: InboundEvent) {}
+    async fn on_peer_event(&self, _: PeerIdHash, _: InboundEvent) {}
 
-    async fn next(&self, _: PeerId256) -> OutboundEvent {
+    async fn next(&self, _: PeerIdHash) -> OutboundEvent {
         futures::future::pending().await
     }
 }

--- a/devp2p/src/types.rs
+++ b/devp2p/src/types.rs
@@ -5,8 +5,7 @@ use auto_impl::auto_impl;
 use bytes::Bytes;
 use derive_more::Display;
 use educe::Educe;
-pub use ethereum_types::H256 as PeerId256;
-pub use ethereum_types::H512 as PeerId512;
+pub use ethereum_types::{H256 as PeerId256, H512 as PeerId512};
 use rlp::{DecoderError, Rlp, RlpStream};
 use std::{collections::HashMap, fmt::Debug, net::SocketAddr, str::FromStr};
 

--- a/devp2p/src/types.rs
+++ b/devp2p/src/types.rs
@@ -122,20 +122,20 @@ pub enum OutboundEvent {
 #[auto_impl(&, Box, Arc)]
 pub trait CapabilityServer: Send + Sync + 'static {
     /// Should be used to set up relevant state for the peer.
-    fn on_peer_connect(&self, peer: PeerId512, caps: HashMap<CapabilityName, CapabilityVersion>);
+    fn on_peer_connect(&self, peer: PeerId256, caps: HashMap<CapabilityName, CapabilityVersion>);
     /// Called on the next event for peer.
-    async fn on_peer_event(&self, peer: PeerId512, event: InboundEvent);
+    async fn on_peer_event(&self, peer: PeerId256, event: InboundEvent);
     /// Get the next event for peer.
-    async fn next(&self, peer: PeerId512) -> OutboundEvent;
+    async fn next(&self, peer: PeerId256) -> OutboundEvent;
 }
 
 #[async_trait]
 impl CapabilityServer for () {
-    fn on_peer_connect(&self, _: PeerId512, _: HashMap<CapabilityName, CapabilityVersion>) {}
+    fn on_peer_connect(&self, _: PeerId256, _: HashMap<CapabilityName, CapabilityVersion>) {}
 
-    async fn on_peer_event(&self, _: PeerId512, _: InboundEvent) {}
+    async fn on_peer_event(&self, _: PeerId256, _: InboundEvent) {}
 
-    async fn next(&self, _: PeerId512) -> OutboundEvent {
+    async fn next(&self, _: PeerId256) -> OutboundEvent {
         futures::future::pending().await
     }
 }

--- a/devp2p/src/types.rs
+++ b/devp2p/src/types.rs
@@ -5,7 +5,7 @@ use auto_impl::auto_impl;
 use bytes::Bytes;
 use derive_more::Display;
 use educe::Educe;
-pub use ethereum_types::H512 as PeerId;
+pub use ethereum_types::H512 as PeerId512;
 use rlp::{DecoderError, Rlp, RlpStream};
 use std::{collections::HashMap, fmt::Debug, net::SocketAddr, str::FromStr};
 
@@ -13,7 +13,7 @@ use std::{collections::HashMap, fmt::Debug, net::SocketAddr, str::FromStr};
 #[derive(Clone, Copy, Debug)]
 pub struct NodeRecord {
     /// Node ID.
-    pub id: PeerId,
+    pub id: PeerId512,
     /// Address of RLPx TCP server.
     pub addr: SocketAddr,
 }
@@ -121,20 +121,20 @@ pub enum OutboundEvent {
 #[auto_impl(&, Box, Arc)]
 pub trait CapabilityServer: Send + Sync + 'static {
     /// Should be used to set up relevant state for the peer.
-    fn on_peer_connect(&self, peer: PeerId, caps: HashMap<CapabilityName, CapabilityVersion>);
+    fn on_peer_connect(&self, peer: PeerId512, caps: HashMap<CapabilityName, CapabilityVersion>);
     /// Called on the next event for peer.
-    async fn on_peer_event(&self, peer: PeerId, event: InboundEvent);
+    async fn on_peer_event(&self, peer: PeerId512, event: InboundEvent);
     /// Get the next event for peer.
-    async fn next(&self, peer: PeerId) -> OutboundEvent;
+    async fn next(&self, peer: PeerId512) -> OutboundEvent;
 }
 
 #[async_trait]
 impl CapabilityServer for () {
-    fn on_peer_connect(&self, _: PeerId, _: HashMap<CapabilityName, CapabilityVersion>) {}
+    fn on_peer_connect(&self, _: PeerId512, _: HashMap<CapabilityName, CapabilityVersion>) {}
 
-    async fn on_peer_event(&self, _: PeerId, _: InboundEvent) {}
+    async fn on_peer_event(&self, _: PeerId512, _: InboundEvent) {}
 
-    async fn next(&self, _: PeerId) -> OutboundEvent {
+    async fn next(&self, _: PeerId512) -> OutboundEvent {
         futures::future::pending().await
     }
 }

--- a/devp2p/src/types.rs
+++ b/devp2p/src/types.rs
@@ -5,6 +5,7 @@ use auto_impl::auto_impl;
 use bytes::Bytes;
 use derive_more::Display;
 use educe::Educe;
+pub use ethereum_types::H256 as PeerId256;
 pub use ethereum_types::H512 as PeerId512;
 use rlp::{DecoderError, Rlp, RlpStream};
 use std::{collections::HashMap, fmt::Debug, net::SocketAddr, str::FromStr};

--- a/devp2p/src/util.rs
+++ b/devp2p/src/util.rs
@@ -34,6 +34,10 @@ pub fn id512_to_pk(id512: PeerId512) -> Result<PublicKey, secp256k1::Error> {
     PublicKey::from_slice(&s)
 }
 
+pub fn id512_to_id256(id512: PeerId512) -> PeerId256 {
+    keccak256(id512.as_bytes())
+}
+
 pub fn hex_debug<T: AsRef<[u8]>>(s: &T, f: &mut Formatter) -> fmt::Result {
     f.write_str(&hex::encode(&s))
 }

--- a/devp2p/src/util.rs
+++ b/devp2p/src/util.rs
@@ -23,7 +23,7 @@ pub fn hmac_sha256(key: &[u8], input: &[&[u8]], auth_data: &[u8]) -> H256 {
     H256::from_slice(&*hmac.finalize().into_bytes())
 }
 
-pub fn pk2id(pk: &PublicKey) -> PeerId512 {
+pub fn pk_to_id512(pk: &PublicKey) -> PeerId512 {
     PeerId512::from_slice(&pk.serialize_uncompressed()[1..])
 }
 
@@ -44,9 +44,9 @@ mod tests {
     use secp256k1::{SecretKey, SECP256K1};
 
     #[test]
-    fn pk2id2pk() {
+    fn pk_to_id512_to_pk() {
         let prikey = SecretKey::new(&mut secp256k1::rand::thread_rng());
         let pubkey = PublicKey::from_secret_key(SECP256K1, &prikey);
-        assert_eq!(pubkey, id2pk(pk2id(&pubkey)).unwrap());
+        assert_eq!(pubkey, id2pk(pk_to_id512(&pubkey)).unwrap());
     }
 }

--- a/devp2p/src/util.rs
+++ b/devp2p/src/util.rs
@@ -23,11 +23,11 @@ pub fn hmac_sha256(key: &[u8], input: &[&[u8]], auth_data: &[u8]) -> H256 {
     H256::from_slice(&*hmac.finalize().into_bytes())
 }
 
-pub fn pk2id(pk: &PublicKey) -> PeerId {
-    PeerId::from_slice(&pk.serialize_uncompressed()[1..])
+pub fn pk2id(pk: &PublicKey) -> PeerId512 {
+    PeerId512::from_slice(&pk.serialize_uncompressed()[1..])
 }
 
-pub fn id2pk(id: PeerId) -> Result<PublicKey, secp256k1::Error> {
+pub fn id2pk(id: PeerId512) -> Result<PublicKey, secp256k1::Error> {
     let mut s = [0_u8; 65];
     s[0] = 4;
     s[1..].copy_from_slice(id.as_bytes());

--- a/devp2p/src/util.rs
+++ b/devp2p/src/util.rs
@@ -27,10 +27,10 @@ pub fn pk_to_id512(pk: &PublicKey) -> PeerId512 {
     PeerId512::from_slice(&pk.serialize_uncompressed()[1..])
 }
 
-pub fn id2pk(id: PeerId512) -> Result<PublicKey, secp256k1::Error> {
+pub fn id512_to_pk(id512: PeerId512) -> Result<PublicKey, secp256k1::Error> {
     let mut s = [0_u8; 65];
     s[0] = 4;
-    s[1..].copy_from_slice(id.as_bytes());
+    s[1..].copy_from_slice(id512.as_bytes());
     PublicKey::from_slice(&s)
 }
 
@@ -47,6 +47,6 @@ mod tests {
     fn pk_to_id512_to_pk() {
         let prikey = SecretKey::new(&mut secp256k1::rand::thread_rng());
         let pubkey = PublicKey::from_secret_key(SECP256K1, &prikey);
-        assert_eq!(pubkey, id2pk(pk_to_id512(&pubkey)).unwrap());
+        assert_eq!(pubkey, id512_to_pk(pk_to_id512(&pubkey)).unwrap());
     }
 }

--- a/devp2p/src/util.rs
+++ b/devp2p/src/util.rs
@@ -23,19 +23,19 @@ pub fn hmac_sha256(key: &[u8], input: &[&[u8]], auth_data: &[u8]) -> H256 {
     H256::from_slice(&*hmac.finalize().into_bytes())
 }
 
-pub fn pk_to_id512(pk: &PublicKey) -> PeerId512 {
-    PeerId512::from_slice(&pk.serialize_uncompressed()[1..])
+pub fn pk_to_id_pub_key(pk: &PublicKey) -> PeerIdPubKey {
+    PeerIdPubKey::from_slice(&pk.serialize_uncompressed()[1..])
 }
 
-pub fn id512_to_pk(id512: PeerId512) -> Result<PublicKey, secp256k1::Error> {
+pub fn id_pub_key_to_pk(id_pub_key: PeerIdPubKey) -> Result<PublicKey, secp256k1::Error> {
     let mut s = [0_u8; 65];
     s[0] = 4;
-    s[1..].copy_from_slice(id512.as_bytes());
+    s[1..].copy_from_slice(id_pub_key.as_bytes());
     PublicKey::from_slice(&s)
 }
 
-pub fn id512_to_id256(id512: PeerId512) -> PeerId256 {
-    keccak256(id512.as_bytes())
+pub fn id_pub_key_to_id_hash(id_pub_key: PeerIdPubKey) -> PeerIdHash {
+    keccak256(id_pub_key.as_bytes())
 }
 
 pub fn hex_debug<T: AsRef<[u8]>>(s: &T, f: &mut Formatter) -> fmt::Result {
@@ -48,9 +48,9 @@ mod tests {
     use secp256k1::{SecretKey, SECP256K1};
 
     #[test]
-    fn pk_to_id512_to_pk() {
+    fn pk_to_id_pub_key_to_pk() {
         let prikey = SecretKey::new(&mut secp256k1::rand::thread_rng());
         let pubkey = PublicKey::from_secret_key(SECP256K1, &prikey);
-        assert_eq!(pubkey, id512_to_pk(pk_to_id512(&pubkey)).unwrap());
+        assert_eq!(pubkey, id_pub_key_to_pk(pk_to_id_pub_key(&pubkey)).unwrap());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -510,7 +510,7 @@ async fn main() -> anyhow::Result<()> {
     info!(
         "Node ID: {}",
         hex::encode(
-            devp2p::util::pk2id(&PublicKey::from_secret_key(SECP256K1, &secret_key)).as_bytes()
+            devp2p::util::pk_to_id512(&PublicKey::from_secret_key(SECP256K1, &secret_key)).as_bytes()
         )
     );
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -510,7 +510,8 @@ async fn main() -> anyhow::Result<()> {
     info!(
         "Node ID: {}",
         hex::encode(
-            devp2p::util::pk_to_id512(&PublicKey::from_secret_key(SECP256K1, &secret_key)).as_bytes()
+            devp2p::util::pk_to_id512(&PublicKey::from_secret_key(SECP256K1, &secret_key))
+                .as_bytes()
         )
     );
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,12 +62,12 @@ struct Pipes {
 
 #[derive(Clone, Debug, Default)]
 struct BlockTracker {
-    block_by_peer: HashMap<PeerId512, u64>,
-    peers_by_block: BTreeMap<u64, HashSet<PeerId512>>,
+    block_by_peer: HashMap<PeerId256, u64>,
+    peers_by_block: BTreeMap<u64, HashSet<PeerId256>>,
 }
 
 impl BlockTracker {
-    fn set_block_number(&mut self, peer: PeerId512, block: u64, force_create: bool) {
+    fn set_block_number(&mut self, peer: PeerId256, block: u64, force_create: bool) {
         match self.block_by_peer.entry(peer) {
             HashMapEntry::Vacant(e) => {
                 if force_create {
@@ -91,7 +91,7 @@ impl BlockTracker {
         self.peers_by_block.entry(block).or_default().insert(peer);
     }
 
-    fn remove_peer(&mut self, peer: PeerId512) {
+    fn remove_peer(&mut self, peer: PeerId256) {
         if let Some(block) = self.block_by_peer.remove(&peer) {
             if let Entry::Occupied(mut entry) = self.peers_by_block.entry(block) {
                 entry.get_mut().remove(&peer);
@@ -103,7 +103,7 @@ impl BlockTracker {
         }
     }
 
-    fn peers_with_min_block(&self, block: u64) -> HashSet<PeerId512> {
+    fn peers_with_min_block(&self, block: u64) -> HashSet<PeerId256> {
         self.peers_by_block
             .range(block..)
             .map(|(_, v)| v)
@@ -117,12 +117,12 @@ impl BlockTracker {
 #[educe(Debug)]
 pub struct CapabilityServerImpl {
     #[educe(Debug(ignore))]
-    peer_pipes: Arc<RwLock<HashMap<PeerId512, Pipes>>>,
+    peer_pipes: Arc<RwLock<HashMap<PeerId256, Pipes>>>,
     block_tracker: Arc<RwLock<BlockTracker>>,
 
     status_message: Arc<RwLock<Option<FullStatusData>>>,
     protocol_version: EthProtocolVersion,
-    valid_peers: Arc<RwLock<HashSet<PeerId512>>>,
+    valid_peers: Arc<RwLock<HashSet<PeerId256>>>,
 
     data_sender: BroadcastSender<InboundMessage>,
     peers_status_sender: BroadcastSender<PeersReply>,
@@ -131,29 +131,29 @@ pub struct CapabilityServerImpl {
 }
 
 impl CapabilityServerImpl {
-    fn setup_peer(&self, peer: PeerId512, p: Pipes) {
+    fn setup_peer(&self, peer: PeerId256, p: Pipes) {
         let mut pipes = self.peer_pipes.write();
         let mut block_tracker = self.block_tracker.write();
 
         assert!(pipes.insert(peer, p).is_none());
         block_tracker.set_block_number(peer, 0, true);
     }
-    fn get_pipes(&self, peer: PeerId512) -> Option<Pipes> {
+    fn get_pipes(&self, peer: PeerId256) -> Option<Pipes> {
         self.peer_pipes.read().get(&peer).cloned()
     }
-    pub fn sender(&self, peer: PeerId512) -> Option<OutboundSender> {
+    pub fn sender(&self, peer: PeerId256) -> Option<OutboundSender> {
         self.peer_pipes
             .read()
             .get(&peer)
             .map(|pipes| pipes.sender.clone())
     }
-    fn receiver(&self, peer: PeerId512) -> Option<OutboundReceiver> {
+    fn receiver(&self, peer: PeerId256) -> Option<OutboundReceiver> {
         self.peer_pipes
             .read()
             .get(&peer)
             .map(|pipes| pipes.receiver.clone())
     }
-    fn teardown_peer(&self, peer: PeerId512) {
+    fn teardown_peer(&self, peer: PeerId256) {
         let mut pipes = self.peer_pipes.write();
         let mut block_tracker = self.block_tracker.write();
         let mut valid_peers = self.valid_peers.write();
@@ -163,7 +163,7 @@ impl CapabilityServerImpl {
         valid_peers.remove(&peer);
 
         let send_status_result = self.peers_status_sender.send(grpc::sentry::PeersReply {
-            peer_id: Some(ethereum_interfaces::types::H512::from(peer)),
+            peer_id: Some(peer.into()),
             event: grpc::sentry::peers_reply::PeerEvent::Disconnect as i32,
         });
         if let Err(error) = send_status_result {
@@ -171,7 +171,7 @@ impl CapabilityServerImpl {
         }
     }
 
-    pub fn all_peers(&self) -> HashSet<PeerId512> {
+    pub fn all_peers(&self) -> HashSet<PeerId256> {
         self.peer_pipes.read().keys().copied().collect()
     }
 
@@ -187,7 +187,7 @@ impl CapabilityServerImpl {
     #[instrument(skip(self))]
     async fn handle_event(
         &self,
-        peer: PeerId512,
+        peer: PeerId256,
         event: InboundEvent,
     ) -> Result<Option<Message>, DisconnectReason> {
         match event {
@@ -227,7 +227,7 @@ impl CapabilityServerImpl {
 
                             let send_status_result =
                                 self.peers_status_sender.send(grpc::sentry::PeersReply {
-                                    peer_id: Some(ethereum_interfaces::types::H512::from(peer)),
+                                    peer_id: Some(peer.into()),
                                     event: grpc::sentry::peers_reply::PeerEvent::Connect as i32,
                                 });
                             if let Err(error) = send_status_result {
@@ -263,7 +263,7 @@ impl CapabilityServerImpl {
 #[async_trait]
 impl CapabilityServer for CapabilityServerImpl {
     #[instrument(skip(self, peer), level = "debug", fields(peer=&*peer.to_string()))]
-    fn on_peer_connect(&self, peer: PeerId512, caps: HashMap<CapabilityName, CapabilityVersion>) {
+    fn on_peer_connect(&self, peer: PeerId256, caps: HashMap<CapabilityName, CapabilityVersion>) {
         let first_events = if let Some(FullStatusData {
             status,
             fork_filter,
@@ -311,7 +311,7 @@ impl CapabilityServer for CapabilityServerImpl {
         );
     }
     #[instrument(skip(self, peer, event), level = "debug", fields(peer=&*peer.to_string(), event=&*event.to_string()))]
-    async fn on_peer_event(&self, peer: PeerId512, event: InboundEvent) {
+    async fn on_peer_event(&self, peer: PeerId256, event: InboundEvent) {
         debug!("Received message");
 
         if let Some(ev) = self.handle_event(peer, event).await.transpose() {
@@ -330,7 +330,7 @@ impl CapabilityServer for CapabilityServerImpl {
     }
 
     #[instrument(skip(self, peer), level = "debug", fields(peer=&*peer.to_string()))]
-    async fn next(&self, peer: PeerId512) -> OutboundEvent {
+    async fn next(&self, peer: PeerId256) -> OutboundEvent {
         self.receiver(peer)
             .unwrap()
             .lock()

--- a/src/services/sentry.rs
+++ b/src/services/sentry.rs
@@ -43,7 +43,7 @@ impl SentryService {
     ) -> SentPeers
     where
         F: FnOnce(&CapabilityServerImpl) -> IT,
-        IT: IntoIterator<Item = PeerId256>,
+        IT: IntoIterator<Item = PeerIdHash>,
     {
         let result = self.try_send_by_predicate(request, pred).await;
         result.unwrap_or_else(|error| {
@@ -62,7 +62,7 @@ impl SentryService {
     ) -> anyhow::Result<SentPeers>
     where
         F: FnOnce(&CapabilityServerImpl) -> IT,
-        IT: IntoIterator<Item = PeerId256>,
+        IT: IntoIterator<Item = PeerIdHash>,
     {
         let request = request.ok_or_else(|| anyhow::anyhow!("empty request"))?;
 
@@ -93,8 +93,8 @@ impl SentryService {
     async fn send_message(
         &self,
         message: Message,
-        peer: devp2p::PeerId256,
-    ) -> anyhow::Result<devp2p::PeerId256> {
+        peer: devp2p::PeerIdHash,
+    ) -> anyhow::Result<devp2p::PeerIdHash> {
         let sender = self
             .capability_server
             .sender(peer)

--- a/src/services/sentry.rs
+++ b/src/services/sentry.rs
@@ -43,7 +43,7 @@ impl SentryService {
     ) -> SentPeers
     where
         F: FnOnce(&CapabilityServerImpl) -> IT,
-        IT: IntoIterator<Item = PeerId512>,
+        IT: IntoIterator<Item = PeerId256>,
     {
         let result = self.try_send_by_predicate(request, pred).await;
         result.unwrap_or_else(|error| {
@@ -62,7 +62,7 @@ impl SentryService {
     ) -> anyhow::Result<SentPeers>
     where
         F: FnOnce(&CapabilityServerImpl) -> IT,
-        IT: IntoIterator<Item = PeerId512>,
+        IT: IntoIterator<Item = PeerId256>,
     {
         let request = request.ok_or_else(|| anyhow::anyhow!("empty request"))?;
 
@@ -93,8 +93,8 @@ impl SentryService {
     async fn send_message(
         &self,
         message: Message,
-        peer: devp2p::PeerId512,
-    ) -> anyhow::Result<devp2p::PeerId512> {
+        peer: devp2p::PeerId256,
+    ) -> anyhow::Result<devp2p::PeerId256> {
         let sender = self
             .capability_server
             .sender(peer)

--- a/src/services/sentry.rs
+++ b/src/services/sentry.rs
@@ -43,7 +43,7 @@ impl SentryService {
     ) -> SentPeers
     where
         F: FnOnce(&CapabilityServerImpl) -> IT,
-        IT: IntoIterator<Item = PeerId>,
+        IT: IntoIterator<Item = PeerId512>,
     {
         let result = self.try_send_by_predicate(request, pred).await;
         result.unwrap_or_else(|error| {
@@ -62,7 +62,7 @@ impl SentryService {
     ) -> anyhow::Result<SentPeers>
     where
         F: FnOnce(&CapabilityServerImpl) -> IT,
-        IT: IntoIterator<Item = PeerId>,
+        IT: IntoIterator<Item = PeerId512>,
     {
         let request = request.ok_or_else(|| anyhow::anyhow!("empty request"))?;
 
@@ -93,8 +93,8 @@ impl SentryService {
     async fn send_message(
         &self,
         message: Message,
-        peer: devp2p::PeerId,
-    ) -> anyhow::Result<devp2p::PeerId> {
+        peer: devp2p::PeerId512,
+    ) -> anyhow::Result<devp2p::PeerId512> {
         let sender = self
             .capability_server
             .sender(peer)


### PR DESCRIPTION
Addresses the immediate compatibility issue in #22 without being too invasive.

The usage changes from `PeerId512` to `PeerId256` at a clean boundary starting from `rlpx::setup_peer_state()` after the transport-level peer handshake has completed.